### PR TITLE
Hotfix: Bug in longitudinal resonator wake

### DIFF
--- a/impedances/wakes.py
+++ b/impedances/wakes.py
@@ -471,7 +471,6 @@ class Resonator(WakeSource):
         omegabar = np.sqrt(np.abs(omega**2 - alpha**2))
 
         def wake(dt, *args, **kwargs):
-            dt = dt.clip(max=0)
             if self.Q > 0.5:
                 y = (-(np.sign(dt) - 1) * self.R_shunt * alpha *
                      np.exp(alpha * dt) * (cos(omegabar * dt) +


### PR DESCRIPTION
- Remove clip which resulted in accumulation of dt == 0 values (corresponding to a non-zero wake :/)