### PR TITLE
Hotfix: overflow problem in RF matched distribution

### DIFF
--- a/PyHEADTAIL/particles/generators.py
+++ b/PyHEADTAIL/particles/generators.py
@@ -630,8 +630,9 @@ class StationaryExponential(object):
         self.width = width
 
     def function(self, z, dp):
-        psi = np.exp(self.H(z, dp).clip(min=0)/self.H0) - 1
-        psi_norm = np.exp(self.Hmax/self.H0) - 1
+        H_hat = self.H(0., 0.).clip(min=0)
+        psi = np.exp((self.H(z, dp).clip(min=0)-H_hat)/self.H0) - np.exp(-H_hat/self.H0)
+        psi_norm = np.exp((self.Hmax-H_hat)/self.H0) - np.exp(-H_hat/self.H0)
         return psi/psi_norm
 
 

--- a/PyHEADTAIL/testing/script-tests/test_synchrotron_electrons_CLIC_DR.py
+++ b/PyHEADTAIL/testing/script-tests/test_synchrotron_electrons_CLIC_DR.py
@@ -5,8 +5,8 @@ sys.path.append(BIN)
 
 from scipy.constants import e,c
 
-macroparticlenumber_track = 50000
-macroparticlenumber_optics = 2000000
+macroparticlenumber_track = 2000
+macroparticlenumber_optics = 2000
 n_turns = 512*4
 
 epsn_x  = 0.456e-6
@@ -25,7 +25,7 @@ machine = CLIC_DR(machine_configuration='3TeV', n_segments=29,
 
 
 print 'Create bunch for optics...'
-bunch   = machine.generate_6D_Gaussian_bunch(
+bunch   = machine.generate_6D_Gaussian_bunch_matched(
     macroparticlenumber_optics, intensity, epsn_x, epsn_y, sigma_z=sigma_z)
 print 'Done.'
 
@@ -82,7 +82,7 @@ plt.show()
 
 
 machine.one_turn_map.insert(ix, machine.longitudinal_map)
-bunch   = machine.generate_6D_Gaussian_bunch(
+bunch   = machine.generate_6D_Gaussian_bunch_matched(
     macroparticlenumber_track, intensity, epsn_x, epsn_y, sigma_z=sigma_z)
 
 beam_x = []


### PR DESCRIPTION
Hotfix: Very short bunches failed to converge for the RF matching due to overflows before.

@like2000 suggests to add @giadarol 's solution to this in the new release, let's go :D