### PR TITLE
Feature/longdistmatching

### DIFF
--- a/PyHEADTAIL/particles/generators.py
+++ b/PyHEADTAIL/particles/generators.py
@@ -9,7 +9,7 @@ from __future__ import division
 import numpy as np
 
 from particles import Particles
-from rfbucket_matching import RFBucketMatcher, StationaryExponential
+from rfbucket_matching import RFBucketMatcher, ThermalDistribution
 
 from . import Printing
 
@@ -132,7 +132,7 @@ def longitudinal_linear_matcher(Qs, eta, C):
 
 
 def RF_bucket_distribution(rfbucket, sigma_z=None, epsn_z=None,
-                           margin=0, distribution_type=StationaryExponential,
+                           margin=0, distribution_type=ThermalDistribution,
                            *args, **kwargs):
     '''Return a distribution function which generates particles
     which are matched to the specified bucket and target emittance or std
@@ -143,6 +143,9 @@ def RF_bucket_distribution(rfbucket, sigma_z=None, epsn_z=None,
         epsn_z: target normalized emittance in z-direction
         margin: relative margin from the separatrix towards the
             inner stable fix point in which particles are avoided
+        distribution_type: longitudinal distribution type from
+            rfbucket_matching (default is ThermalDistribution which
+            produces a Gaussian-like matched Boltzmann distribution)
     Returns:
         A matcher with the specified bucket properties (closure)
     Raises:

--- a/PyHEADTAIL/particles/generators.py
+++ b/PyHEADTAIL/particles/generators.py
@@ -619,7 +619,7 @@ class RFBucketMatcher(Printing):
 
 class StationaryExponential(object):
 
-    def __init__(self, H, Hmax=None, width=1000, Hcut=0):
+    def __init__(self, H, Hmax=None, Hcut=0):
         self.H = H
         self.H0 = 1
         if not Hmax:
@@ -627,13 +627,12 @@ class StationaryExponential(object):
         else:
             self.Hmax = Hmax
         self.Hcut = Hcut
-        self.width = width
+
+    def _psi(self, H):
+        return np.exp((H - self.Hmax) / self.H0) - np.exp(-self.Hmax / self.H0)
 
     def function(self, z, dp):
-        H_hat = self.H(0., 0.).clip(min=0)
-        psi = np.exp((self.H(z, dp).clip(min=0)-H_hat)/self.H0) - np.exp(-H_hat/self.H0)
-        psi_norm = np.exp((self.Hmax-H_hat)/self.H0) - np.exp(-H_hat/self.H0)
-        return psi/psi_norm
+        return self._psi(self.H(z, dp).clip(min=0)) / self._psi(self.Hmax)
 
 
 class HEADTAILcoords(object):

--- a/PyHEADTAIL/particles/generators.py
+++ b/PyHEADTAIL/particles/generators.py
@@ -9,14 +9,10 @@ from __future__ import division
 import numpy as np
 
 from particles import Particles
-from scipy.optimize import brentq, newton
-# from ..trackers.rf_bucket import RFBucket
-
-from ..cobra_functions.pdf_integrators_2d import quad2d
+from rfbucket_matching import RFBucketMatcher, StationaryExponential
 
 from . import Printing
 
-from functools import partial
 from scipy.constants import e, c
 
 
@@ -136,7 +132,8 @@ def longitudinal_linear_matcher(Qs, eta, C):
 
 
 def RF_bucket_distribution(rfbucket, sigma_z=None, epsn_z=None,
-                           margin=0, *args, **kwargs):
+                           margin=0, distribution_type=StationaryExponential,
+                           *args, **kwargs):
     '''Return a distribution function which generates particles
     which are matched to the specified bucket and target emittance or std
     Specify only one of sigma_z, epsn_z
@@ -151,7 +148,7 @@ def RF_bucket_distribution(rfbucket, sigma_z=None, epsn_z=None,
     Raises:
         ValueError: If neither or both of sigma_z, epsn_z are specified
     '''
-    rf_bucket_matcher_impl = RFBucketMatcher(rfbucket, StationaryExponential,
+    rf_bucket_matcher_impl = RFBucketMatcher(rfbucket, distribution_type,
                                              sigma_z=sigma_z, epsn_z=epsn_z,
                                              *args, **kwargs)
 
@@ -417,222 +414,6 @@ def kv4D(r_x, r_xp, r_y, r_yp):
         xp, yp = r_xp * rp * np.cos(t), r_yp * rp * np.sin(t)
         return [x, xp, y, yp]
     return _kv4d
-
-
-class RFBucketMatcher(Printing):
-
-    def __init__(self, rfbucket, psi, sigma_z=None, epsn_z=None,
-                 verbose_regeneration=False, *args, **kwargs):
-
-        self.rfbucket = rfbucket
-        hamiltonian = partial(rfbucket.hamiltonian, make_convex=True)
-        hmax = rfbucket.h_sfp(make_convex=True)
-
-        self.psi_object = psi(hamiltonian, hmax)
-        self.psi = self.psi_object.function
-
-        self.verbose_regeneration = verbose_regeneration
-
-        if sigma_z and not epsn_z:
-            self.variable = sigma_z
-            self.psi_for_variable = self.psi_for_bunchlength_newton_method
-        elif not sigma_z and epsn_z:
-            self.variable = epsn_z
-            self.psi_for_variable = self.psi_for_emittance_newton_method
-        else:
-            raise ValueError("Can not generate mismatched matched " +
-                             "distribution! (Don't provide both sigma_z " +
-                             "and epsn_z!)")
-
-    def psi_for_emittance_newton_method(self, epsn_z):
-
-        # Maximum emittance
-        self.psi_object.H0 = self.rfbucket.guess_H0(
-            self.rfbucket.circumference, from_variable='sigma')
-        epsn_max = self._compute_emittance(self.rfbucket, self.psi)
-        if epsn_z > epsn_max:
-            self.warns('Given RMS emittance does not fit into bucket. ' +
-                       'Using (maximum) full bucket emittance ' +
-                       str(epsn_max*0.99) + 'eV s instead.')
-            epsn_z = epsn_max*0.99
-        self.prints('*** Maximum RMS emittance ' + str(epsn_max) + 'eV s.')
-
-        def get_zc_for_epsn_z(ec):
-            self.psi_object.H0 = self.rfbucket.guess_H0(
-                ec, from_variable='epsn')
-            emittance = self._compute_emittance(self.rfbucket, self.psi)
-
-            self.prints('... distance to target emittance: ' +
-                        '{:.2e}'.format(emittance-epsn_z))
-
-            return emittance-epsn_z
-
-        try:
-            ec_bar = newton(get_zc_for_epsn_z, epsn_z, tol=5e-4)
-        except RuntimeError:
-            self.warns('RFBucketMatcher -- failed to converge while ' +
-                       'using Newton-Raphson method. ' +
-                       'Instead trying classic Brent method...')
-            ec_bar = brentq(get_zc_for_epsn_z, epsn_z/2, 2*epsn_max)
-
-        self.psi_object.H0 = self.rfbucket.guess_H0(
-            ec_bar, from_variable='epsn')
-        emittance = self._compute_emittance(self.rfbucket, self.psi)
-        self.prints('--> Emittance: ' + str(emittance))
-        sigma = self._compute_sigma(self.rfbucket, self.psi)
-        self.prints('--> Bunch length:' + str(sigma))
-
-    def psi_for_bunchlength_newton_method(self, sigma):
-
-        # Maximum bunch length
-        self.psi_object.H0 = self.rfbucket.guess_H0(
-            self.rfbucket.circumference, from_variable='sigma')
-        sigma_max = self._compute_sigma(self.rfbucket, self.psi)
-        if sigma > sigma_max:
-            self.warns('Given RMS bunch length does not fit into bucket. ' +
-                       'Using (maximum) full bucket RMS bunch length ' +
-                       str(sigma_max*0.99) + 'm instead.')
-            sigma = sigma_max*0.99
-        self.prints('*** Maximum RMS bunch length ' + str(sigma_max) + 'm.')
-
-        def get_zc_for_sigma(zc):
-            '''Width for bunch length'''
-            self.psi_object.H0 = self.rfbucket.guess_H0(
-                zc, from_variable='sigma')
-            length = self._compute_sigma(self.rfbucket, self.psi)
-
-            if np.isnan(length): raise ValueError
-
-            self.prints('... distance to target bunch length: ' +
-                        '{:.4e}'.format(length-sigma))
-
-            return length-sigma
-
-        zc_bar = newton(get_zc_for_sigma, sigma)
-
-        self.psi_object.H0 = self.rfbucket.guess_H0(
-            zc_bar, from_variable='sigma')
-        sigma = self._compute_sigma(self.rfbucket, self.psi)
-        self.prints('--> Bunch length: ' + str(sigma))
-        emittance = self._compute_emittance(self.rfbucket, self.psi)
-        self.prints('--> Emittance: ' + str(emittance))
-
-    def linedensity(self, xx):
-        quad_type = fixed_quad
-
-        L = []
-        try:
-            L = np.array([quad_type(lambda y: self.psi(x, y), 0,
-                                    self.p_limits(x))[0] for x in xx])
-        except TypeError:
-            L = quad_type(lambda y: self.psi(xx, y), 0, self.p_limits(xx))[0]
-        L = np.array(L)
-
-        return 2*L
-
-    def generate(self, macroparticlenumber, cutting_margin=0):
-        '''Generate a 2d phase space of n_particles particles randomly distributed
-        according to the particle distribution function psi within the region
-        [xmin, xmax, ymin, ymax].
-        '''
-        self.psi_for_variable(self.variable)
-
-        xmin, xmax = self.rfbucket.z_left, self.rfbucket.z_right
-        ymin = -self.rfbucket.dp_max(self.rfbucket.z_right)
-        ymax = -ymin
-
-        # rejection sampling
-        uniform = np.random.uniform
-        n_gen = macroparticlenumber
-        u = uniform(low=xmin, high=xmax, size=n_gen)
-        v = uniform(low=ymin, high=ymax, size=n_gen)
-        s = uniform(size=n_gen)
-
-        def mask_out(s, u, v):
-            return s >= self.psi(u, v)
-
-        if cutting_margin:
-            mask_out_nocut = mask_out
-
-            def mask_out(s, u, v):
-                return np.logical_or(
-                    mask_out_nocut(s, u, v),
-                    ~self.rfbucket.is_in_separatrix(u, v, cutting_margin))
-
-        # masked_out = ~(s<self.psi(u, v))
-        masked_out = mask_out(s, u, v)
-        while np.any(masked_out):
-            masked_ids = np.where(masked_out)[0]
-            n_gen = len(masked_ids)
-            u[masked_out] = uniform(low=xmin, high=xmax, size=n_gen)
-            v[masked_out] = uniform(low=ymin, high=ymax, size=n_gen)
-            s[masked_out] = uniform(size=n_gen)
-            # masked_out = ~(s<self.psi(u, v))
-            masked_out[masked_ids] = mask_out(
-                s[masked_out], u[masked_out], v[masked_out]
-            )
-            if self.verbose_regeneration:
-                self.prints(
-                    'Thou shalt not give up! :-) '
-                    'Regenerating {0} macro-particles...'.format(n_gen))
-
-        return u, v, self.psi, self.linedensity
-
-    def _compute_sigma(self, rfbucket, psi):
-
-        f = lambda x, y: self.psi(x, y)
-        Q = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)
-        f = lambda x, y: psi(x, y)*x
-        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
-        f = lambda x, y: psi(x, y)*(x-M)**2
-        V = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
-        var_x = V
-
-        return np.sqrt(var_x)
-
-    def _compute_emittance(self, rfbucket, psi):
-
-        f = lambda x, y: self.psi(x, y)
-        Q = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)
-
-        f = lambda x, y: psi(x, y)*x
-        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
-        f = lambda x, y: psi(x, y)*(x-M)**2
-        V = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
-        mean_x = M
-        var_x  = V
-
-        f = lambda x, y: psi(x, y)*y
-        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
-        f = lambda x, y: psi(x, y)*(y-M)**2
-        V = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
-        mean_y = M
-        var_y  = V
-
-        f = lambda x, y: psi(x, y)*(x-mean_x)*(y-mean_y)
-        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
-        mean_xy = M
-
-        return (np.sqrt(var_x*var_y - mean_xy**2) *
-                4*np.pi*rfbucket.p0/np.abs(rfbucket.charge))
-
-
-class StationaryExponential(object):
-
-    def __init__(self, H, Hmax=None, Hcut=0):
-        self.H = H
-        self.H0 = 1
-        if not Hmax:
-            self.Hmax = H(0, 0)
-        else:
-            self.Hmax = Hmax
-        self.Hcut = Hcut
-
-    def _psi(self, H):
-        return np.exp((H - self.Hmax) / self.H0) - np.exp(-self.Hmax / self.H0)
-
-    def function(self, z, dp):
-        return self._psi(self.H(z, dp).clip(min=0)) / self._psi(self.Hmax)
 
 
 class HEADTAILcoords(object):

--- a/PyHEADTAIL/particles/rfbucket_matching.py
+++ b/PyHEADTAIL/particles/rfbucket_matching.py
@@ -267,3 +267,46 @@ class ThermalDistribution(StationaryDistribution):
 
 # backwards compatibility:
 StationaryExponential = ThermalDistribution
+
+class QGaussianDistribution(StationaryDistribution):
+    '''Specific Tsallis q-Gaussian distribution for q=3/5 for now,
+    leading to \psi ~ (1 - H/H0)^2, this may be generalised.
+    '''
+    n = 2
+
+    def _psi(self, H):
+        # convert from convex Hamiltonian
+        # (SFP being the maximum and the separatrix having zero value)
+        # to conventional scale (zero-valued minimum at SFP)
+        Hsep = self.Hcut + self.Hmax
+        Hn = Hsep - H
+        dist = (1 - Hn / self.H0).clip(min=self.Hcut)**self.n
+        return dist.clip(min=self.Hcut)
+
+class ParabolicDistribution(StationaryDistribution):
+    '''The parabolic profile distribution is a specific case of the
+    present implementation of the q-Gaussian distribution for n = 1/2,
+    \psi ~ \sqrt(1 - H/H0).
+    For a quadratic harmonic oscillator Hamiltonian this distribution
+    provides a parabolic line density.
+    '''
+    def _psi(self, H):
+        # convert from convex Hamiltonian
+        # (SFP being the maximum and the separatrix having zero value)
+        # to conventional scale (zero-valued minimum at SFP)
+        Hsep = self.Hcut + self.Hmax
+        Hn = Hsep - H
+        return np.sqrt((1 - Hn / self.H0).clip(min=self.Hcut))
+
+class WaterbagDistribution(StationaryDistribution):
+    '''The waterbag distribution has a constant Hamiltonian distribution
+    until a cutoff, \psi ~ \Theta(H - H0) with \Theta the Heaviside
+    step function.
+    '''
+    def _psi(self, H):
+        # convert from convex Hamiltonian
+        # (SFP being the maximum and the separatrix having zero value)
+        # to conventional scale (zero-valued minimum at SFP)
+        Hsep = self.Hcut + self.Hmax
+        Hn = Hsep - H
+        return np.piecewise(Hn, [Hn <= self.H0, Hn > self.H0], [1./self.H0, 0])

--- a/PyHEADTAIL/particles/rfbucket_matching.py
+++ b/PyHEADTAIL/particles/rfbucket_matching.py
@@ -251,8 +251,7 @@ class StationaryDistribution(object):
         norm = self._psi(self.Hmax)
         return psi / norm
 
-
-class StationaryExponential(StationaryDistribution):
+class ThermalDistribution(StationaryDistribution):
     '''Thermal Boltzmann distribution \psi ~ \exp(-H/H0).
     For a quadratic harmonic oscillator Hamiltonian this gives the
     bi-Gaussian phase space distribution.
@@ -265,3 +264,6 @@ class StationaryExponential(StationaryDistribution):
         Hn = Hsep - H
         # f(Hn) - f(Hsep)
         return np.exp(-Hn / self.H0) - np.exp(-Hsep / self.H0)
+
+# backwards compatibility:
+StationaryExponential = ThermalDistribution

--- a/PyHEADTAIL/particles/rfbucket_matching.py
+++ b/PyHEADTAIL/particles/rfbucket_matching.py
@@ -1,0 +1,245 @@
+'''
+@author Kevin Li, Adrian Oeftiger, Stefan Hegglin
+@date 16.06.2017
+@brief module for matching longitudinal particle distributions to an RFBucket instance
+'''
+
+from __future__ import division, print_function
+
+import numpy as np
+from scipy.optimize import brentq, newton
+from scipy.constants import e, c
+
+from ..cobra_functions.pdf_integrators_2d import quad2d
+
+from . import Printing
+
+from functools import partial
+
+class RFBucketMatcher(Printing):
+
+    def __init__(self, rfbucket, distribution_type=None, sigma_z=None,
+                 epsn_z=None, verbose_regeneration=False, psi=None,
+                 *args, **kwargs):
+
+        if psi is not None:
+            self.warns('\n\n*** DEPRECATED: keyword argument "psi" will '
+                       'be removed in a future PyHEADTAIL release!')
+            if distribution_type is not None:
+                raise TypeError('RFBucketMatcher accepts either '
+                                'distribution_type or psi as argument. ')
+        else:
+            if distribution_type is None:
+                raise TypeError(
+                    '__init__() takes at least 2 arguments (1 given)\n'
+                    '--> kwarg psi has been renamed to distribution_type.')
+
+        self.rfbucket = rfbucket
+        hamiltonian = partial(rfbucket.hamiltonian, make_convex=True)
+        hmax = rfbucket.h_sfp(make_convex=True)
+
+        self.psi_object = distribution_type(hamiltonian, hmax)
+        self.psi = self.psi_object.function
+
+        self.verbose_regeneration = verbose_regeneration
+
+        if sigma_z and not epsn_z:
+            self.variable = sigma_z
+            self.psi_for_variable = self.psi_for_bunchlength_newton_method
+        elif not sigma_z and epsn_z:
+            self.variable = epsn_z
+            self.psi_for_variable = self.psi_for_emittance_newton_method
+        else:
+            raise ValueError("Can not generate mismatched matched " +
+                             "distribution! (Don't provide both sigma_z " +
+                             "and epsn_z!)")
+
+    def psi_for_emittance_newton_method(self, epsn_z):
+
+        # Maximum emittance
+        self.psi_object.H0 = self.rfbucket.guess_H0(
+            self.rfbucket.circumference, from_variable='sigma')
+        epsn_max = self._compute_emittance(self.rfbucket, self.psi)
+        if epsn_z > epsn_max:
+            self.warns('Given RMS emittance does not fit into bucket. ' +
+                       'Using (maximum) full bucket emittance ' +
+                       str(epsn_max*0.99) + 'eV s instead.')
+            epsn_z = epsn_max*0.99
+        self.prints('*** Maximum RMS emittance ' + str(epsn_max) + 'eV s.')
+
+        def get_zc_for_epsn_z(ec):
+            self.psi_object.H0 = self.rfbucket.guess_H0(
+                ec, from_variable='epsn')
+            emittance = self._compute_emittance(self.rfbucket, self.psi)
+
+            self.prints('... distance to target emittance: ' +
+                        '{:.2e}'.format(emittance-epsn_z))
+
+            return emittance-epsn_z
+
+        try:
+            ec_bar = newton(get_zc_for_epsn_z, epsn_z, tol=5e-4)
+        except RuntimeError:
+            self.warns('RFBucketMatcher -- failed to converge while ' +
+                       'using Newton-Raphson method. ' +
+                       'Instead trying classic Brent method...')
+            ec_bar = brentq(get_zc_for_epsn_z, epsn_z/2, 2*epsn_max)
+
+        self.psi_object.H0 = self.rfbucket.guess_H0(
+            ec_bar, from_variable='epsn')
+        emittance = self._compute_emittance(self.rfbucket, self.psi)
+        self.prints('--> Emittance: ' + str(emittance))
+        sigma = self._compute_sigma(self.rfbucket, self.psi)
+        self.prints('--> Bunch length:' + str(sigma))
+
+    def psi_for_bunchlength_newton_method(self, sigma):
+
+        # Maximum bunch length
+        self.psi_object.H0 = self.rfbucket.guess_H0(
+            self.rfbucket.circumference, from_variable='sigma')
+        sigma_max = self._compute_sigma(self.rfbucket, self.psi)
+        if sigma > sigma_max:
+            self.warns('Given RMS bunch length does not fit into bucket. ' +
+                       'Using (maximum) full bucket RMS bunch length ' +
+                       str(sigma_max*0.99) + 'm instead.')
+            sigma = sigma_max*0.99
+        self.prints('*** Maximum RMS bunch length ' + str(sigma_max) + 'm.')
+
+        def get_zc_for_sigma(zc):
+            '''Width for bunch length'''
+            self.psi_object.H0 = self.rfbucket.guess_H0(
+                zc, from_variable='sigma')
+            length = self._compute_sigma(self.rfbucket, self.psi)
+
+            if np.isnan(length): raise ValueError
+
+            self.prints('... distance to target bunch length: ' +
+                        '{:.4e}'.format(length-sigma))
+
+            return length-sigma
+
+        zc_bar = newton(get_zc_for_sigma, sigma)
+
+        self.psi_object.H0 = self.rfbucket.guess_H0(
+            zc_bar, from_variable='sigma')
+        sigma = self._compute_sigma(self.rfbucket, self.psi)
+        self.prints('--> Bunch length: ' + str(sigma))
+        emittance = self._compute_emittance(self.rfbucket, self.psi)
+        self.prints('--> Emittance: ' + str(emittance))
+
+    def linedensity(self, xx):
+        quad_type = fixed_quad
+
+        L = []
+        try:
+            L = np.array([quad_type(lambda y: self.psi(x, y), 0,
+                                    self.p_limits(x))[0] for x in xx])
+        except TypeError:
+            L = quad_type(lambda y: self.psi(xx, y), 0, self.p_limits(xx))[0]
+        L = np.array(L)
+
+        return 2*L
+
+    def generate(self, macroparticlenumber, cutting_margin=0):
+        '''Generate a 2d phase space of n_particles particles randomly distributed
+        according to the particle distribution function psi within the region
+        [xmin, xmax, ymin, ymax].
+        '''
+        self.psi_for_variable(self.variable)
+
+        xmin, xmax = self.rfbucket.z_left, self.rfbucket.z_right
+        ymin = -self.rfbucket.dp_max(self.rfbucket.z_right)
+        ymax = -ymin
+
+        # rejection sampling
+        uniform = np.random.uniform
+        n_gen = macroparticlenumber
+        u = uniform(low=xmin, high=xmax, size=n_gen)
+        v = uniform(low=ymin, high=ymax, size=n_gen)
+        s = uniform(size=n_gen)
+
+        def mask_out(s, u, v):
+            return s >= self.psi(u, v)
+
+        if cutting_margin:
+            mask_out_nocut = mask_out
+
+            def mask_out(s, u, v):
+                return np.logical_or(
+                    mask_out_nocut(s, u, v),
+                    ~self.rfbucket.is_in_separatrix(u, v, cutting_margin))
+
+        # masked_out = ~(s<self.psi(u, v))
+        masked_out = mask_out(s, u, v)
+        while np.any(masked_out):
+            masked_ids = np.where(masked_out)[0]
+            n_gen = len(masked_ids)
+            u[masked_out] = uniform(low=xmin, high=xmax, size=n_gen)
+            v[masked_out] = uniform(low=ymin, high=ymax, size=n_gen)
+            s[masked_out] = uniform(size=n_gen)
+            # masked_out = ~(s<self.psi(u, v))
+            masked_out[masked_ids] = mask_out(
+                s[masked_out], u[masked_out], v[masked_out]
+            )
+            if self.verbose_regeneration:
+                self.prints(
+                    'Thou shalt not give up! :-) '
+                    'Regenerating {0} macro-particles...'.format(n_gen))
+
+        return u, v, self.psi, self.linedensity
+
+    def _compute_sigma(self, rfbucket, psi):
+
+        f = lambda x, y: self.psi(x, y)
+        Q = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)
+        f = lambda x, y: psi(x, y)*x
+        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        f = lambda x, y: psi(x, y)*(x-M)**2
+        V = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        var_x = V
+
+        return np.sqrt(var_x)
+
+    def _compute_emittance(self, rfbucket, psi):
+
+        f = lambda x, y: self.psi(x, y)
+        Q = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)
+
+        f = lambda x, y: psi(x, y)*x
+        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        f = lambda x, y: psi(x, y)*(x-M)**2
+        V = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        mean_x = M
+        var_x  = V
+
+        f = lambda x, y: psi(x, y)*y
+        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        f = lambda x, y: psi(x, y)*(y-M)**2
+        V = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        mean_y = M
+        var_y  = V
+
+        f = lambda x, y: psi(x, y)*(x-mean_x)*(y-mean_y)
+        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        mean_xy = M
+
+        return (np.sqrt(var_x*var_y - mean_xy**2) *
+                4*np.pi*rfbucket.p0/np.abs(rfbucket.charge))
+
+
+class StationaryExponential(object):
+
+    def __init__(self, H, Hmax=None, Hcut=0):
+        self.H = H
+        self.H0 = 1
+        if not Hmax:
+            self.Hmax = H(0, 0)
+        else:
+            self.Hmax = Hmax
+        self.Hcut = Hcut
+
+    def _psi(self, H):
+        return np.exp((H - self.Hmax) / self.H0) - np.exp(-self.Hmax / self.H0)
+
+    def function(self, z, dp):
+        return self._psi(self.H(z, dp).clip(min=0)) / self._psi(self.Hmax)


### PR DESCRIPTION
Support for different longitudinal distributions in RFBucket matching:
- thermal (as before)
- q-Gaussian (specifically for q=3/5 for now, as in the LHC after blow-up)
- parabolic
- waterbag (this one takes ultra-long to converge with the present moment computation)

Putting this intermediate status into develop branch for Kevin already.
What remains to be done:
- improve moment computation (`_compute_sigma`, `_compute_emittance`) -- probably the incontinuity in the derivative of the new distributions (and even more the jump in the waterbag distribution) are a problem for the present `dbl_quad` computation

Examples with these distributions have been presented in https://indico.cern.ch/event/643949/contributions/2613672/attachments/1474360/2282923/hllhc_headtails.pdf.