### PR TITLE
Feature/longdistmatching

### DIFF
--- a/PyHEADTAIL/cobra_functions/pdf_integrators_2d.py
+++ b/PyHEADTAIL/cobra_functions/pdf_integrators_2d.py
@@ -122,71 +122,174 @@ def compute_cov_quad(psi, ylimit_min, ylimit_max, xmin, xmax):
 
     return V_x, C_xy, V_y
 
-def compute_zero_cumtrapz(psi, ylimits, xmin, xmax, n_samples=257):
+### scipy.integrate.cumtrapz moment integration:
 
-    x_arr = np.linspace(xmin, xmax, n_samples)
+def compute_zero_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax,
+                          n_samples=513):
+    '''Compute the zeroth moment of the distribution function psi from
+    xmin to xmax between the contours ylimit_min and ylimit_max
+    (e.g. an RFBucket separatrix) using the numerical
+    scipy.integrate.cumtrapz integration method.
+
+    Arguments:
+        - psi: 2D distribution function with two arguments x and y
+        - ylimit_min, ylimit_max: contour functions yielding the lower
+          and the upper y(x) limit for given x
+        - xmin, xmax: lower and upper limit in the first argument of psi
+        - n_samples: integer number of sampling points for integration
+    '''
+
+    x_arr = np.linspace(xmin, xmax, num=n_samples)
     dx = x_arr[1] - x_arr[0]
 
     Q = 0
     for x in x_arr:
-        y = np.linspace(0, ylimits(x), n_samples)
+        y = np.linspace(ylimit_min(x), ylimit_max(x), num=n_samples)
         z = psi(x, y)
         Q += cumtrapz(z, y)[-1]
     Q *= dx
 
     return Q
 
-def compute_mean_cumtrapz(psi, ylimits, xmin, xmax, n_samples=257):
+def compute_mean_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax,
+                          direction='x', n_samples=513):
+    '''Compute the first moment of the distribution function psi from
+    xmin to xmax between the contours ylimit_min and ylimit_max
+    (e.g. an RFBucket separatrix) using the numerical
+    scipy.integrate.cumtrapz integration method.
 
-    Q = compute_zero_cumtrapz(psi, ylimits, xmin, xmax, n_samples)
+    Arguments:
+        - psi: 2D distribution function with two arguments x and y
+        - ylimit_min, ylimit_max: contour functions yielding the lower
+          and the upper y(x) limit for given x
+        - xmin, xmax: lower and upper limit in the first argument of psi
+        - direction: 'x' or 'y' for calculating the mean in the first
+          or second argument of psi, respectively (default: 'x')
+        - n_samples: integer number of sampling points for integration
+    '''
 
-    x_arr = np.linspace(xmin, xmax, n_samples)
+    Q = compute_zero_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax,
+                              n_samples)
+
+    x_arr = np.linspace(xmin, xmax, num=n_samples)
     dx = x_arr[1] - x_arr[0]
+
+    if direction is 'x':
+        f = lambda x, y: x * psi(x, y)
+    elif direction is 'y':
+        f = lambda x, y: y * psi(x, y)
+    else:
+        raise ValueError('direction needs to be either "x" or "y".')
 
     M = 0
     for x in x_arr:
-        y = np.linspace(0, ylimits(x), n_samples)
-        z = x * psi(x, y)
+        y = np.linspace(ylimit_min(x), ylimit_max(x), num=n_samples)
+        z = f(x, y)
         M += cumtrapz(z, y)[-1]
     M *= dx
 
     return M/Q
 
-def compute_std_cumtrapz(psi, ylimits, xmin, xmax, n_samples=257):
-    '''
-    Compute the variance of the distribution function psi from xmin
-    to xmax along the contours ylimits using numerical integration
-    methods.
+def compute_var_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax,
+                         direction='x', n_samples=513):
+    '''Compute the second moment (variance) with respect to the x or
+    y direction of the distribution function psi from xmin to xmax
+    between the contours ylimit_min and ylimit_max
+    (e.g. an RFBucket separatrix) using the numerical
+    scipy.integrate.cumtrapz integration method.
+
+    Arguments:
+        - psi: 2D distribution function with two arguments x and y
+        - ylimit_min, ylimit_max: contour functions yielding the lower
+          and the upper y(x) limit for given x
+        - xmin, xmax: lower and upper limit in the first argument of psi
+        - direction: 'x' or 'y' for calculating the mean in the first
+          or second argument of psi, respectively (default: 'x')
+        - n_samples: integer number of sampling points for integration
     '''
 
-    Q = compute_zero_cumtrapz(psi, ylimits, xmin, xmax, n_samples)
-    M = compute_mean_cumtrapz(psi, ylimits, xmin, xmax, n_samples)
+    Q = compute_zero_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax,
+                              n_samples)
+    M = compute_mean_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax,
+                              direction, n_samples)
 
-    x_arr = np.linspace(xmin, xmax, n_samples)
+    x_arr = np.linspace(xmin, xmax, num=n_samples)
     dx = x_arr[1] - x_arr[0]
+
+    if direction is 'x':
+        f = lambda x, y: (x - M)**2 * psi(x, y)
+    elif direction is 'y':
+        f = lambda x, y: (y - M)**2 * psi(x, y)
+    else:
+        raise ValueError('direction needs to be either "x" or "y".')
 
     V = 0
     for x in x_arr:
-        y = np.linspace(0, ylimits(x), n_samples)
-        z = (x-M)**2 * psi(x, y)
+        y = np.linspace(ylimit_min(x), ylimit_max(x), num=n_samples)
+        z = f(x, y)
         V += cumtrapz(z, y)[-1]
     V *= dx
 
-    return np.sqrt(V/Q)
+    return V/Q
 
-def compute_std_romberg(psi, ylimits, xmin, xmax, n_samples=257):
-    '''
-    Compute the variance of the distribution function psi from xmin
-    to xmax along the contours ylimits using numerical integration
-    methods.
+def compute_cov_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax,
+                         n_samples=513):
+    '''Compute the second moments (covariance matrix entries) of the
+    distribution function psi from xmin to xmax between the contours
+    ylimit_min and ylimit_max (e.g. an RFBucket separatrix) using the
+    numerical scipy.integrate.cumtrapz integration method.
+    For x the first and y the second argument of psi, return the tuple
+    (variance(x), covariance(x,y), variance(y)).
+
+    Arguments:
+        - psi: 2D distribution function with two arguments x and y
+        - ylimit_min, ylimit_max: contour functions yielding the lower
+          and the upper y(x) limit for given x
+        - xmin, xmax: lower and upper limit in the first argument of psi
+        - n_samples: integer number of sampling points for integration
     '''
 
-    x_arr = np.linspace(xmin, xmax, n_samples)
+
+    Q = compute_zero_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax)
+    M_x = compute_mean_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax, 'x')
+    M_y = compute_mean_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax, 'y')
+
+    V_x = compute_var_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax, 'x')
+    V_y = compute_var_cumtrapz(psi, ylimit_min, ylimit_max, xmin, xmax, 'y')
+
+    x_arr = np.linspace(xmin, xmax, num=n_samples)
+    dx = x_arr[1] - x_arr[0]
+
+    C_xy = 0
+    for x in x_arr:
+        y = np.linspace(ylimit_min(x), ylimit_max(x), num=n_samples)
+        z = (x - M_x) * (y - M_y) * psi(x, y)
+        C_xy += cumtrapz(z, y)[-1]
+    C_xy *= dx
+
+    C_xy /= Q
+
+    return V_x, C_xy, V_y
+
+
+### scipy.integrate.romberg standard deviation integration:
+### ==> not yet adapted to above quad and cumtrapz approaches,
+###     works as Kevin had previously defined it in the RFBucketMatcher
+###     (slightly corrected to make this function work here)
+
+def compute_std_romberg(psi, ylimits, xmin, xmax, n_samples=513):
+    '''
+    Compute the standard deviation of the distribution function psi
+    from xmin to xmax along the contours ylimits using numerical
+    integration methods.
+    '''
+
+    x_arr = np.linspace(xmin, xmax, num=n_samples)
     dx = x_arr[1] - x_arr[0]
 
     Q, V = 0, 0
     for x in x_arr:
-        y = np.linspace(0, ylimits(x), n_samples)
+        y = np.linspace(0, ylimits(x), num=n_samples)
         dy = y[1] - y[0]
         z = psi(x, y)
         Q += romb(z, dy)

--- a/PyHEADTAIL/cobra_functions/pdf_integrators_2d.py
+++ b/PyHEADTAIL/cobra_functions/pdf_integrators_2d.py
@@ -1,12 +1,24 @@
-from scipy.integrate import quad, fixed_quad, dblquad, cumtrapz, romb
+'''
+@author Kevin Li, Adrian Oeftiger
+@date 21.06.2017
+@brief 2D distribution integration methods for y(x) parametrised domains
+'''
+from scipy.integrate import quad, dblquad, cumtrapz, romb
+
+import numpy as np
 
 
 def quad2d(f, ylimits, xmin, xmax):
+    '''Integrate 2D function f=f(x,y) over interval [xmin,xmax] and
+    between contours [-ylimits(x), ylimits(x)] using the numerical
+    scipy.integrate.dblquad integration method.
+    '''
     Q, error = dblquad(lambda y, x: f(x, y), xmin, xmax,
                        lambda x: -ylimits(x), lambda x: ylimits(x))
 
     return Q
 
+### scipy.integrate.dblquad moment integration:
 
 def compute_zero_quad(psi, ylimit_min, ylimit_max, xmin, xmax):
     '''Compute the zeroth moment of the distribution function psi from
@@ -94,9 +106,6 @@ def compute_cov_quad(psi, ylimit_min, ylimit_max, xmin, xmax):
         - psi: 2D distribution function with two arguments x and y
         - ylimits: contour function yielding the y(x) limit for given x
         - xmin, xmax: lower and upper limit in the first argument of psi
-
-    NB: assumes a symmetric distribution function with respect to the
-    second argument (the vertical direction).
     '''
 
     Q = compute_zero_quad(psi, ylimit_min, ylimit_max, xmin, xmax)

--- a/PyHEADTAIL/cobra_functions/pdf_integrators_2d.py
+++ b/PyHEADTAIL/cobra_functions/pdf_integrators_2d.py
@@ -8,110 +8,176 @@ def quad2d(f, ylimits, xmin, xmax):
     return Q
 
 
-def _compute_zero_quad(self, psi, p_sep, xmin, xmax):
-    '''
-    Compute the variance of the distribution function psi from xmin
-    to xmax along the contours p_sep using numerical integration
-    methods.
-    '''
+def compute_zero_quad(psi, ylimit_min, ylimit_max, xmin, xmax):
+    '''Compute the zeroth moment of the distribution function psi from
+    xmin to xmax between the contours ylimit_min and ylimit_max
+    (e.g. an RFBucket separatrix) using the numerical
+    scipy.integrate.dblquad integration method.
 
+    Arguments:
+        - psi: 2D distribution function with two arguments x and y
+        - ylimit_min, ylimit_max: contour functions yielding the lower
+          and the upper y(x) limit for given x
+        - xmin, xmax: lower and upper limit in the first argument of psi
+    '''
     Q, error = dblquad(lambda y, x: psi(x, y), xmin, xmax,
-                lambda x: 0, lambda x: p_sep(x))
+                       ylimit_min, ylimit_max)
 
     return Q
 
-def _compute_mean_quad(self, psi, p_sep, xmin, xmax):
-    '''
-    Compute the variance of the distribution function psi from xmin
-    to xmax along the contours p_sep using numerical integration
-    methods.
+def compute_mean_quad(psi, ylimit_min, ylimit_max, xmin, xmax, direction='x'):
+    '''Compute the first moment of the distribution function psi from
+    xmin to xmax between the contours ylimit_min and ylimit_max
+    (e.g. an RFBucket separatrix) using the numerical
+    scipy.integrate.dblquad integration method.
+
+    Arguments:
+        - psi: 2D distribution function with two arguments x and y
+        - ylimit_min, ylimit_max: contour functions yielding the lower
+          and the upper y(x) limit for given x
+        - xmin, xmax: lower and upper limit in the first argument of psi
+        - direction: 'x' or 'y' for calculating the mean in the first
+          or second argument of psi, respectively (default: 'x')
     '''
 
-    Q = self._compute_zero_quad(psi, p_sep, xmin, xmax)
-    M, error = dblquad(lambda y, x: x * psi(x, y), xmin, xmax,
-                lambda x: 0, lambda x: p_sep(x))
+    Q = compute_zero_quad(psi, ylimit_min, ylimit_max, xmin, xmax)
+    if direction is 'x':
+        f = lambda y, x: x * psi(x, y)
+    elif direction is 'y':
+        f = lambda y, x: y * psi(x, y)
+    else:
+        raise ValueError('direction needs to be either "x" or "y".')
+
+    M, error = dblquad(f, xmin, xmax, ylimit_min, ylimit_max)
 
     return M/Q
 
-def _compute_std_quad(self, psi, p_sep, xmin, xmax):
+def compute_var_quad(psi, ylimit_min, ylimit_max, xmin, xmax, direction='x'):
+    '''Compute the second moment (variance) with respect to the x or
+    y direction of the distribution function psi from xmin to xmax
+    between the contours ylimit_min and ylimit_max (e.g. an RFBucket
+    separatrix) using the numerical scipy.integrate.dblquad integration
+    method.
+
+    Arguments:
+        - psi: 2D distribution function with two arguments x and y
+        - ylimit_min, ylimit_max: contour functions yielding the lower
+          and the upper y(x) limit for given x
+        - xmin, xmax: lower and upper limit in the first argument of psi
+        - direction: 'x' or 'y' for calculating the standard deviation
+          in the first or second argument of psi, respectively
+          (default: 'x')
     '''
-    Compute the variance of the distribution function psi from xmin
-    to xmax along the contours p_sep using numerical integration
-    methods.
+
+    Q = compute_zero_quad(psi, ylimit_min, ylimit_max, xmin, xmax)
+    M = compute_mean_quad(psi, ylimit_min, ylimit_max, xmin, xmax, direction)
+    if direction is 'x':
+        f = lambda y, x: (x - M)**2 * psi(x, y)
+    elif direction is 'y':
+        f = lambda y, x: (y - M)**2 * psi(x, y)
+    else:
+        raise ValueError('direction needs to be either "x" or "y".')
+
+    V, error = dblquad(f, xmin, xmax, ylimit_min, ylimit_max)
+
+    return V/Q
+
+def compute_cov_quad(psi, ylimit_min, ylimit_max, xmin, xmax):
+    '''Compute the second moments (covariance matrix entries) of the
+    distribution function psi from xmin to xmax between the contours
+    ylimit_min and ylimit_max (e.g. an RFBucket separatrix) using the
+    numerical scipy.integrate.dblquad integration method.
+    For x the first and y the second argument of psi, return the tuple
+    (variance(x), covariance(x,y), variance(y)).
+
+    Arguments:
+        - psi: 2D distribution function with two arguments x and y
+        - ylimits: contour function yielding the y(x) limit for given x
+        - xmin, xmax: lower and upper limit in the first argument of psi
+
+    NB: assumes a symmetric distribution function with respect to the
+    second argument (the vertical direction).
     '''
 
-    Q = self._compute_zero_quad(psi, p_sep, xmin, xmax)
-    M = self._compute_mean_quad(psi, p_sep, xmin, xmax)
-    V, error = dblquad(lambda y, x: (x-M) ** 2 * psi(x, y), xmin, xmax,
-                       lambda x: 0, lambda x: p_sep(x))
+    Q = compute_zero_quad(psi, ylimit_min, ylimit_max, xmin, xmax)
+    M_x = compute_mean_quad(psi, ylimit_min, ylimit_max, xmin, xmax, 'x')
+    M_y = compute_mean_quad(psi, ylimit_min, ylimit_max, xmin, xmax, 'y')
 
-    return np.sqrt(V/Q)
+    V_x = compute_var_quad(psi, ylimit_min, ylimit_max, xmin, xmax, 'x')
+    V_y = compute_var_quad(psi, ylimit_min, ylimit_max, xmin, xmax, 'y')
 
-def _compute_zero_cumtrapz(self, psi, p_sep, xmin, xmax):
+    f = lambda y, x: (x - M_x) * (y - M_y) * psi(x, y)
+    C_xy, error = dblquad(f, xmin, xmax, ylimit_min, ylimit_max)
 
-    x_arr = np.linspace(xmin, xmax, 257)
+    C_xy /= Q
+
+    return V_x, C_xy, V_y
+
+def compute_zero_cumtrapz(psi, ylimits, xmin, xmax, n_samples=257):
+
+    x_arr = np.linspace(xmin, xmax, n_samples)
     dx = x_arr[1] - x_arr[0]
 
     Q = 0
     for x in x_arr:
-        y = np.linspace(0, p_sep(x), 257)
+        y = np.linspace(0, ylimits(x), n_samples)
         z = psi(x, y)
         Q += cumtrapz(z, y)[-1]
     Q *= dx
 
     return Q
 
-def _compute_mean_cumtrapz(self, psi, p_sep, xmin, xmax):
+def compute_mean_cumtrapz(psi, ylimits, xmin, xmax, n_samples=257):
 
-    Q = self._compute_zero_cumtrapz(psi, p_sep, xmin, xmax)
+    Q = compute_zero_cumtrapz(psi, ylimits, xmin, xmax, n_samples)
 
-    x_arr = np.linspace(xmin, xmax, 257)
+    x_arr = np.linspace(xmin, xmax, n_samples)
     dx = x_arr[1] - x_arr[0]
 
     M = 0
     for x in x_arr:
-        y = np.linspace(0, p_sep(x), 257)
+        y = np.linspace(0, ylimits(x), n_samples)
         z = x * psi(x, y)
         M += cumtrapz(z, y)[-1]
     M *= dx
 
     return M/Q
 
-def _compute_std_cumtrapz(self, psi, p_sep, xmin, xmax):
+def compute_std_cumtrapz(psi, ylimits, xmin, xmax, n_samples=257):
     '''
     Compute the variance of the distribution function psi from xmin
-    to xmax along the contours p_sep using numerical integration
+    to xmax along the contours ylimits using numerical integration
     methods.
     '''
 
-    Q = self._compute_zero_cumtrapz(psi, p_sep, xmin, xmax)
-    M = self._compute_mean_cumtrapz(psi, p_sep, xmin, xmax)
+    Q = compute_zero_cumtrapz(psi, ylimits, xmin, xmax, n_samples)
+    M = compute_mean_cumtrapz(psi, ylimits, xmin, xmax, n_samples)
 
-    x_arr = np.linspace(xmin, xmax, 257)
+    x_arr = np.linspace(xmin, xmax, n_samples)
     dx = x_arr[1] - x_arr[0]
 
     V = 0
     for x in x_arr:
-        y = np.linspace(0, p_sep(x), 257)
+        y = np.linspace(0, ylimits(x), n_samples)
         z = (x-M)**2 * psi(x, y)
         V += cumtrapz(z, y)[-1]
     V *= dx
 
     return np.sqrt(V/Q)
 
-def _compute_std_romberg(self, psi, p_sep, xmin, xmax):
+def compute_std_romberg(psi, ylimits, xmin, xmax, n_samples=257):
     '''
     Compute the variance of the distribution function psi from xmin
-    to xmax along the contours p_sep using numerical integration
+    to xmax along the contours ylimits using numerical integration
     methods.
     '''
 
-    x_arr = np.linspace(xmin, xmax, 257)
+    x_arr = np.linspace(xmin, xmax, n_samples)
     dx = x_arr[1] - x_arr[0]
 
     Q, V = 0, 0
     for x in x_arr:
-        y = np.linspace(0, p_sep(x), 257)
+        y = np.linspace(0, ylimits(x), n_samples)
         dy = y[1] - y[0]
         z = psi(x, y)
         Q += romb(z, dy)

--- a/PyHEADTAIL/particles/generators.py
+++ b/PyHEADTAIL/particles/generators.py
@@ -11,6 +11,9 @@ import numpy as np
 from particles import Particles
 from rfbucket_matching import RFBucketMatcher, ThermalDistribution
 
+# backwards compatibility:
+StationaryExponential = ThermalDistribution
+
 from . import Printing
 
 from scipy.constants import e, c

--- a/PyHEADTAIL/particles/rfbucket_matching.py
+++ b/PyHEADTAIL/particles/rfbucket_matching.py
@@ -279,9 +279,6 @@ class ThermalDistribution(StationaryDistribution):
         # f(Hn) - f(Hsep)
         return np.exp(-Hn / self.H0) - np.exp(-Hsep / self.H0)
 
-# backwards compatibility:
-StationaryExponential = ThermalDistribution
-
 class QGaussianDistribution(StationaryDistribution):
     '''Specific Tsallis q-Gaussian distribution for q=3/5 for now,
     leading to \psi ~ (1 - H/H0)^2, this may be generalised.

--- a/PyHEADTAIL/particles/rfbucket_matching.py
+++ b/PyHEADTAIL/particles/rfbucket_matching.py
@@ -228,14 +228,14 @@ class RFBucketMatcher(Printing):
         var_x  = V
 
         f = lambda x, y: psi(x, y)*y
-        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        M = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
         f = lambda x, y: psi(x, y)*(y-M)**2
-        V = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        V = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
         mean_y = M
         var_y  = V
 
         f = lambda x, y: psi(x, y)*(x-mean_x)*(y-mean_y)
-        M = quad2d(f, rfbucket.separatrix, rfbucket.z_left, rfbucket.z_right)/Q
+        M = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
         mean_xy = M
 
         return (np.sqrt(var_x*var_y - mean_xy**2) *

--- a/PyHEADTAIL/particles/rfbucket_matching.py
+++ b/PyHEADTAIL/particles/rfbucket_matching.py
@@ -11,7 +11,7 @@ from scipy.optimize import brentq, newton
 from scipy.integrate import fixed_quad
 from scipy.constants import e, c
 
-from ..cobra_functions.pdf_integrators_2d import quad2d
+from ..cobra_functions import pdf_integrators_2d as integr
 
 from . import Printing
 
@@ -20,6 +20,19 @@ from functools import partial
 from abc import abstractmethod
 
 class RFBucketMatcher(Printing):
+
+    integrationmethod = ['quad', 'cumtrapz'][0]
+    def get_moment_integrators(self):
+        '''Return moment integrators from
+        cobra_functions.pdf_integrators_2d according to the chosen
+        self.integrationmethod. Allows to change integration method
+        for RFBucket matching.
+        '''
+        zero = getattr(integr, 'compute_zero_' + self.integrationmethod)
+        mean = getattr(integr, 'compute_mean_' + self.integrationmethod)
+        var = getattr(integr, 'compute_var_' + self.integrationmethod)
+        cov = getattr(integr, 'compute_cov_' + self.integrationmethod)
+        return zero, mean, var, cov
 
     def __init__(self, rfbucket, distribution_type=None, sigma_z=None,
                  epsn_z=None, verbose_regeneration=False, psi=None,
@@ -202,43 +215,24 @@ class RFBucketMatcher(Printing):
     def _compute_sigma(self, rfbucket, psi):
         z_left = rfbucket.z_left
         z_right = rfbucket.z_right
+        zero, mean, var, cov = self.get_moment_integrators()
 
-        f = lambda x, y: self.psi(x, y)
-        Q = quad2d(f, rfbucket.separatrix, z_left, z_right)
-        f = lambda x, y: psi(x, y)*x
-        M = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
-        f = lambda x, y: psi(x, y)*(x-M)**2
-        V = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
-        var_x = V
+        var_x = var(self.psi, lambda x: -rfbucket.separatrix(x),
+                    rfbucket.separatrix, z_left, z_right,
+                    direction='x') # x means z direction
 
         return np.sqrt(var_x)
 
     def _compute_emittance(self, rfbucket, psi):
         z_left = rfbucket.z_left
         z_right = rfbucket.z_right
+        zero, mean, var, cov = self.get_moment_integrators()
 
-        f = lambda x, y: self.psi(x, y)
-        Q = quad2d(f, rfbucket.separatrix, z_left, z_right)
+        var_x, cov_xy, var_y = cov(
+            self.psi, lambda x: -rfbucket.separatrix(x),
+            rfbucket.separatrix, z_left, z_right)
 
-        f = lambda x, y: psi(x, y)*x
-        M = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
-        f = lambda x, y: psi(x, y)*(x-M)**2
-        V = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
-        mean_x = M
-        var_x  = V
-
-        f = lambda x, y: psi(x, y)*y
-        M = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
-        f = lambda x, y: psi(x, y)*(y-M)**2
-        V = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
-        mean_y = M
-        var_y  = V
-
-        f = lambda x, y: psi(x, y)*(x-mean_x)*(y-mean_y)
-        M = quad2d(f, rfbucket.separatrix, z_left, z_right)/Q
-        mean_xy = M
-
-        return (np.sqrt(var_x*var_y - mean_xy**2) *
+        return (np.sqrt(var_x*var_y - cov_xy**2) *
                 4*np.pi*rfbucket.p0/np.abs(rfbucket.charge))
 
 


### PR DESCRIPTION
**RFBucket matching extended to new distribution types!**

Updated `cumtrapz` moment integration method makes it possible to match non-smooth distribution types! E.g. the `WaterbagDistribution` has only now become possible to be matched and generate macro-particles! The usually used `quad` moment integration fails to converge on the discontinuous Heaviside step function behaviour of the waterbag. Also q-Gaussian and parabolic distribution matching converges much, much quicker!