### PR TITLE
Hotfix: Type in wakes - failes to load quad wakes correctly.

### DIFF
--- a/impedances/wakes.py
+++ b/impedances/wakes.py
@@ -212,7 +212,7 @@ class WakeTable(WakeSource):
             'dipole_xy':     DipoleWakeKickXY,
             'dipole_yx':     DipoleWakeKickYX,
             'quadrupole_x':  QuadrupoleWakeKickX,
-            'quadrupole_x':  QuadrupoleWakeKickY,
+            'quadrupole_y':  QuadrupoleWakeKickY,
             'quadrupole_xy': QuadrupoleWakeKickXY,
             'quadrupole_yx': QuadrupoleWakeKickYX}
 


### PR DESCRIPTION
@jkomppula : this bug is not even existent in the `master` version (`wakes.py` has been completely overworked by @like2000  2 years ago, I realised) but perhaps you want to incorporate it into your multibunch studies -- the `quadrupolar_y` wake is wrongly referenced in a dictionary. 

This bug was introduced in commit [caf4ef82e027bf57f95d3650b08e04b769242503](https://github.com/PyCOMPLETE/PyHEADTAIL/commit/caf4ef82e027bf57f95d3650b08e04b769242503) .
  