### PR TITLE
Feature/cellmonitor on gpu

### DIFF
--- a/PyHEADTAIL/cobra_functions/stats.pyx
+++ b/PyHEADTAIL/cobra_functions/stats.pyx
@@ -418,8 +418,11 @@ cpdef emittance_per_slice(int[::1] slice_index_of_particle,
 @cython.boundscheck(False)
 @cython.cdivision(True)
 @cython.wraparound(False)
-cpdef calc_cell_stats(bunch, double beta_z, double radial_cut,
-                      int n_rings, int n_azim_slices):
+cpdef calc_cell_stats(
+        double[::1] x, double[::1] xp, double[::1] y,
+        double[::1] yp, double[::1] z, double[::1] dp,
+        double beta_z, double radial_cut,
+        int n_rings, int n_azim_slices):
 
     # Prepare arrays to store cell statistics.
     cdef int[:,::1] n_particles_cell = np.zeros((n_azim_slices, n_rings),
@@ -438,12 +441,12 @@ cpdef calc_cell_stats(bunch, double beta_z, double radial_cut,
                                                dtype=np.double)
 
     # Declare datatypes of bunch coords.
-    cdef double[::1] x = bunch.x
-    cdef double[::1] xp = bunch.xp
-    cdef double[::1] y = bunch.y
-    cdef double[::1] yp = bunch.yp
-    cdef double[::1] z = bunch.z
-    cdef double[::1] dp = bunch.dp
+    # cdef double[::1] x = bunch.x
+    # cdef double[::1] xp = bunch.xp
+    # cdef double[::1] y = bunch.y
+    # cdef double[::1] yp = bunch.yp
+    # cdef double[::1] z = bunch.z
+    # cdef double[::1] dp = bunch.dp
     cdef unsigned int n_particles = x.shape[0]
 
     cdef double ring_width = radial_cut / <double>n_rings

--- a/PyHEADTAIL/monitors/monitors.py
+++ b/PyHEADTAIL/monitors/monitors.py
@@ -571,9 +571,9 @@ class CellMonitor(Monitor):
         them to file. The buffer is implemented as a shift register. The
         cell-specific data are computed by a cython function. """
 
-        from PyHEADTAIL.cobra_functions.stats import calc_cell_stats
-        n_cl, x_cl, xp_cl, y_cl, yp_cl, z_cl, dp_cl = calc_cell_stats(
-            bunch, self.beta_z, self.radial_cut, self.n_radial_slices, self.n_azimuthal_slices)
+        n_cl, x_cl, xp_cl, y_cl, yp_cl, z_cl, dp_cl = cp.calc_cell_stats(
+            bunch, self.beta_z, self.radial_cut, self.n_radial_slices,
+            self.n_azimuthal_slices)
 
         self.buffer_cell['mean_x'][:,:,0] = x_cl[:,:]
         self.buffer_cell['mean_xp'][:,:,0] = xp_cl[:,:]

--- a/PyHEADTAIL/monitors/monitors.py
+++ b/PyHEADTAIL/monitors/monitors.py
@@ -571,8 +571,22 @@ class CellMonitor(Monitor):
         them to file. The buffer is implemented as a shift register. The
         cell-specific data are computed by a cython function. """
 
+        ps_coords = {'x': None, 'xp': None, 'y': None,
+                     'yp': None, 'z': None, 'dp': None}
+        for coord in ps_coords:
+            ps_coords[coord] = getattr(bunch, coord)
+            if pm.device is 'GPU':
+                stream = next(gpu_utils.stream_pool)
+                ps_coords[coord] = ps_coords[coord].get_async(stream=stream)
+        if pm.device is 'GPU':
+            for stream in gpu_utils.streams:
+                stream.synchronize()
+
+        # TODO: calculate these cell stats on the GPU instead of the CPU!!!
         n_cl, x_cl, xp_cl, y_cl, yp_cl, z_cl, dp_cl = cp.calc_cell_stats(
-            bunch, self.beta_z, self.radial_cut, self.n_radial_slices,
+            ps_coords['x'], ps_coords['xp'], ps_coords['y'],
+            ps_coords['yp'], ps_coords['z'], ps_coords['dp'],
+            self.beta_z, self.radial_cut, self.n_radial_slices,
             self.n_azimuthal_slices)
 
         self.buffer_cell['mean_x'][:,:,0] = x_cl[:,:]


### PR DESCRIPTION
Add GPU compatibility for `CellMonitor`.

NB: It would be much nicer to calculate the stats instead of in
cython on the CPU side directly on the GPU and only transfer
the GPU buffer (which is a CPU buffer right now) to the CPU.
This would speed up the `CellMonitor` by a lot!