### PR TITLE
aperture: fixing bug with aperture on GPU...

### DIFF
--- a/PyHEADTAIL/aperture/aperture.py
+++ b/PyHEADTAIL/aperture/aperture.py
@@ -19,7 +19,6 @@ from ..general import pmath as pm
 import numpy as np
 
 def make_int32(array):
-    # return np.array(array, dtype=np.int32)
     return array.astype(np.int32)
 
 
@@ -89,8 +88,9 @@ class Aperture(Element):
 
         beam.reorder(perm)
 
-        n_alive = make_int32(pm.sum(alive))
-        return n_alive
+        # on CPU: (even if pm.device == 'GPU', as pm.sum returns np.ndarray)
+        n_alive = pm.sum(alive)
+        return np.int32(n_alive)
 
 
 class RectangularApertureX(Aperture):


### PR DESCRIPTION
... when running the slice monitor on the GPU, the aperture would
shorten the arrays (via beam.x = beam.x[:n_alive]) in case
of lost particles (n_alive > 0) in a way which is incompatible
with storing the slice statistics.

This only occurs on the GPU (where beam.x would be a GPUArray,
while n_alive has been transformed into a numpy.array because
pm.sum contains a .get() for summing on the GPU).

The fix is to make n_alive a simple integer instead of a
numpy.array...
The usual error message in python2 when only using pm.sum for n_alive:
TypeError: slice indices must be integers or None or have an __index__ method
(therefore wrapping it with a np.int32)

Thanks Eirini for spotting this.