### PR TITLE
setup: adding cython support for python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@
 import numpy as np
 from PyHEADTAIL._version import __version__
 
-import re, os, sys, subprocess
-import numpy as np
+import os, sys, subprocess
 
 from setuptools import setup, Extension, find_packages
 
@@ -55,7 +54,10 @@ with open('README.rst', 'rb') as f:
 # Set up extension and build
 cy_ext_options = {
     "compiler_directives": {"profile": False, # SLOW!!!
-                            "embedsignature": True},
+                            "embedsignature": True,
+                            "linetrace": False,
+                            "language_level": sys.version_info[0],
+                            },
     "annotate": True,
 }
 cy_ext = [


### PR DESCRIPTION
cython requires `compiler_directives={'language_level' : "3"}` for python3 support -- in order to remain compatible with python2, we include

```
cythonize(extensions, compiler_directives={'language_level' : sys.version_info[0]})
```

into the `setup.py` (thanks to [stackoverflow](https://stackoverflow.com/questions/34603628/how-to-specify-python-3-source-in-cythons-setup-py)).