### PR TITLE
gpu_wrap: fix pm.allclose for python3 and numpy>v1.17

### DIFF
--- a/PyHEADTAIL/gpu/gpu_wrap.py
+++ b/PyHEADTAIL/gpu/gpu_wrap.py
@@ -10,7 +10,6 @@ import numpy as np
 import os
 import gpu_utils
 import math
-from functools import wraps
 try:
     import skcuda.misc
     import pycuda.gpuarray
@@ -226,8 +225,8 @@ if has_pycuda:
                   'else notclose[i] = 0;',
         name='allclose_kernel'
     )
-    np_allclose_defaults = np.allclose.func_defaults # (rtol, atol, equal_nan)
-    @wraps(np.allclose)
+    np_allclose_defaults = 1e-05, 1e-08, False
+    #np.allclose.func_defaults # (rtol, atol, equal_nan)
     def allclose(a, b, rtol=np_allclose_defaults[0],
                  atol=np_allclose_defaults[1], out=None, stream=None):
         assert a.shape == b.shape


### PR DESCRIPTION
For python3, `numpy.allclose` does not return function defaults in `__defaults__` from numpy v1.17 on, (v1.16.2 works still). This makes importing `gpu_wrap` fail within `pmath` if pycuda is installed.
The numpy.allclose default values had been read out for consistency in the corresponding GPU implementation within `gpu_wrap`.

This patch inserts the `numpy.allclose` function defaults explicitly in `gpu_wrap.allclose`.