### PR TITLE
Fix/gpu wrap thrust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 endif
 
 errfff:
-	f2py -c PyHEADTAIL/general/errfff.f90 -m errfff
+	f2py3 -c PyHEADTAIL/general/errfff.f90 -m errfff
 	mv errfff*.so PyHEADTAIL/general/
 
 clean:

--- a/PyHEADTAIL/gpu/gpu_wrap.py
+++ b/PyHEADTAIL/gpu/gpu_wrap.py
@@ -17,7 +17,7 @@ try:
     import pycuda.compiler
     import pycuda.driver as drv
     import pycuda.elementwise
-    import PyHEADTAIL.gpu.thrust_interface
+    from PyHEADTAIL.gpu import thrust_interface
 
     # if pycuda is there, try to compile things. If no context available,
     # throw error to tell the user that he should import pycuda.autoinit


### PR DESCRIPTION
`gpu_wrap.py` imports the thrust_interface in absolute but we need it without the top level packages. Typo introduced with python3 compatibility.