### PR TITLE
Fix/transverse tracking dxy lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ else
 endif
 
 errfff:
-	f2py -c PyHEADTAIL/general/errfff.f90 -m errfff
+	f2py3 -c PyHEADTAIL/general/errfff.f90 -m errfff
 	mv errfff*.so PyHEADTAIL/general/
 
 clean:

--- a/PyHEADTAIL/gpu/gpu_wrap.py
+++ b/PyHEADTAIL/gpu/gpu_wrap.py
@@ -17,7 +17,7 @@ try:
     import pycuda.compiler
     import pycuda.driver as drv
     import pycuda.elementwise
-    import PyHEADTAIL.gpu.thrust_interface
+    from PyHEADTAIL.gpu import thrust_interface
 
     # if pycuda is there, try to compile things. If no context available,
     # throw error to tell the user that he should import pycuda.autoinit

--- a/PyHEADTAIL/trackers/transverse_tracking.py
+++ b/PyHEADTAIL/trackers/transverse_tracking.py
@@ -267,7 +267,7 @@ class TransverseMap(Printing):
         self.segment_maps = []
         self._generate_segment_maps()
 
-        if self.D_x.any() or self.D_y.any():
+        if any(self.D_x) or any(self.D_y):
             self.prints('Non-zero dispersion in tracking: '
                         'ensure the beam has been generated '
                         'being matched to the correct dispersion!')

--- a/PyHEADTAIL/trackers/transverse_tracking.py
+++ b/PyHEADTAIL/trackers/transverse_tracking.py
@@ -328,18 +328,27 @@ class TransverseMap(Printing):
 
             self.segment_maps.append(transverse_segment_map)
 
-    def get_injection_optics(self):
+    def get_injection_optics(self, for_particle_generation=False):
         """Return a dict with the transverse TWISS parameters
         alpha_x, beta_x, D_x, alpha_y, beta_y, D_y from the
         beginning of the first segment (injection point).
+
+        The argument for_particle_generation == True names
+        the dispersion "dispersion_x" and not "D_x" as usual,
+        as e.g. required by the function
+        PyHEADTAIL.particles.generators.generate_Gaussian6DTwiss.
         """
+        if for_particle_generation:
+            disp_name = 'dispersion'
+        else:
+            disp_name = 'D'
         return {
             'alpha_x': self.alpha_x[0],
             'beta_x': self.beta_x[0],
-            'D_x': self.D_x[0],
+            disp_name + '_x': self.D_x[0],
             'alpha_y': self.alpha_y[0],
             'beta_y': self.beta_y[0],
-            'D_y': self.D_y[0]
+            disp_name + '_y': self.D_y[0]
         }
 
     def __len__(self):


### PR DESCRIPTION
In transverse tracking it is implicitly assumed that `D_x` and `D_y` have the method `any()` -- which is the case if they are numpy arrays. If instead asking for `any(D_x)` this also works for lists. This patch implements this.