### PR TITLE
GPU: importing pycuda.autoinit missing

### DIFF
--- a/PyHEADTAIL/gpu/gpu_utils.py
+++ b/PyHEADTAIL/gpu/gpu_utils.py
@@ -16,6 +16,7 @@ try:
     has_pycuda = True
     try:
         pycuda.driver.mem_get_info()
+        import pycuda.autoinit
     except pycuda._driver.LogicError: #the error pycuda throws if no context initialized
         # print ('No context initialized. Please import pycuda.autoinit at the '
         #        'beginning of your script if you want to use GPU functionality')


### PR DESCRIPTION
GPU: importing pycuda.autoinit missing
    
if one initialises the GPU device manually and not via
importing pycuda.autoinit externally outside of PyHEADTAIL,
then the previous state here was failing as pycuda.autoinit
is used to retrieve the context -- but it has not been imported.
    
adding an explicit import for now, a better solution in the
future would be to explicitly use the context from the stack
of contexts in the PyCUDA.driver module.
