### PR TITLE
GPU: removing automatic use of streams...

### DIFF
--- a/PyHEADTAIL/general/decorators.py
+++ b/PyHEADTAIL/general/decorators.py
@@ -52,8 +52,9 @@ def synchronize_gpu_streams_before(func):
     synchronized before this function is called
     '''
     def sync_before_wrap(*args, **kwargs):
-        for stream in gpu_utils.streams:
-            stream.synchronize()
+        if gpu_utils.use_streams:
+            for stream in gpu_utils.streams:
+                stream.synchronize()
         return func(*args, **kwargs)
     return sync_before_wrap
 
@@ -64,7 +65,8 @@ def synchronize_gpu_streams_after(func):
     '''
     def sync_after_wrap(*args, **kwargs):
         res = func(*args, **kwargs)
-        for stream in gpu_utils.streams:
-            stream.synchronize()
+        if gpu_utils.use_streams:
+            for stream in gpu_utils.streams:
+                stream.synchronize()
         return res
     return sync_after_wrap

--- a/PyHEADTAIL/gpu/gpu_utils.py
+++ b/PyHEADTAIL/gpu/gpu_utils.py
@@ -6,6 +6,8 @@ The module is automatically a singleton
 @author Stefan Hegglin
 '''
 
+use_streams = False
+
 import atexit
 from itertools import cycle
 
@@ -38,11 +40,16 @@ if has_pycuda:
     atexit.register(skcuda.misc.shutdown)
 
     n_streams = 4
-    streams = [drv.Stream() for i in range(n_streams)]
+    n_streams_emittance = 6
+
+    if use_streams:
+        streams = [drv.Stream() for i in range(n_streams)]
+        stream_emittance = [drv.Stream() for i in range(n_streams_emittance)]
+    else:
+        streams = [None] * n_streams
+        stream_emittance = [None] * n_streams_emittance
+
     stream_pool = cycle(streams)
-
-    stream_emittance = [drv.Stream() for i in range(6)]
-
 
     def dummy_1(gpuarr, stream=None):
         __dummy1(gpuarr, stream=stream)

--- a/PyHEADTAIL/monitors/monitors.py
+++ b/PyHEADTAIL/monitors/monitors.py
@@ -454,8 +454,9 @@ class ParticleMonitor(Monitor):
                 quant_values = quant_values.get_async(stream=stream)
             all_quantities[quant] = quant_values
         if pm.device == 'GPU':
-            for stream in gpu_utils.streams:
-                stream.synchronize()
+            if gpu_utils.use_streams:
+                for stream in gpu_utils.streams:
+                    stream.synchronize()
 
         if arrays_dict is not None:
             all_quantities.update(arrays_dict)
@@ -577,8 +578,9 @@ class CellMonitor(Monitor):
                 stream = next(gpu_utils.stream_pool)
                 ps_coords[coord] = ps_coords[coord].get_async(stream=stream)
         if pm.device == 'GPU':
-            for stream in gpu_utils.streams:
-                stream.synchronize()
+            if gpu_utils.use_streams:
+                for stream in gpu_utils.streams:
+                    stream.synchronize()
 
         # TODO: calculate these cell stats on the GPU instead of the CPU!!!
         n_cl, x_cl, xp_cl, y_cl, yp_cl, z_cl, dp_cl = cp.calc_cell_stats(


### PR DESCRIPTION
... and introducing flag use_streams in gpu_utils
to reenable in the future.

Streams are mostly used for concurrent launches of
kernels computing bunch statistics, both for
slicing as well as the monitors.

Removing the streams leads to serialising which slows
down marginally but makes the simulations more general.
(Here the reason is to interact with other libraries
like SixTrackLib which does not work in streamed computations)