### PR TITLE
Hotfix/longSCbug

### DIFF
--- a/PyHEADTAIL/spacecharge/spacecharge.py
+++ b/PyHEADTAIL/spacecharge/spacecharge.py
@@ -75,8 +75,9 @@ class LongSpaceCharge(Element):
         '''
         slices = beam.get_slices(self.slicer)
         lambda_prime = slices.lambda_prime_bins(sigma=self.n_slice_sigma)
+        lambda_prime_z = lambda_prime / slices.slice_widths[0]
         slice_kicks = (self._prefactor(slices) * self._gfactor(beam) *
-                       lambda_prime) * (self.length / (beam.beta * c))
+                       lambda_prime_z) * (self.length / (beam.beta * c))
 
         kicks = slices.convert_to_particles(slice_kicks)
         beam.dp -= kicks


### PR DESCRIPTION
Thanks a lot to David Kelliher from STFC for pointing out this bug.
Prior to this fix, the longitudinal space charge kicks scaled with the number of slices since the division by the slice widths was missing.
This bug is traceable to the restructuring of the SliceSet in 2015 at latest.

Now the computed force (via make_force) and the actual tracked dp kicks match.