### PR TITLE
Constant wake kicks bug fix

### DIFF
--- a/PyHEADTAIL/impedances/wake_kicks.py
+++ b/PyHEADTAIL/impedances/wake_kicks.py
@@ -157,7 +157,7 @@ class ConstantWakeKickX(WakeKick):
         constant_kick = self._accumulate_source_signal(
             bunch, times_list, slice_set_age_list, moments_list, betas_list)
 
-        p_idx = slice_set_list[0].particles_within_cuts
+        p_idx = slice_set_list[0].particles_within_cuts_slice
         s_idx = pm.take(slice_set_list[0].slice_index_of_particle, p_idx)
         bunch.xp[p_idx] += pm.take(constant_kick, s_idx)
 
@@ -177,7 +177,7 @@ class ConstantWakeKickY(WakeKick):
         constant_kick = self._accumulate_source_signal(
             bunch, times_list, slice_set_age_list, moments_list, betas_list)
 
-        p_idx = slice_set_list[0].particles_within_cuts
+        p_idx = slice_set_list[0].particles_within_cuts_slice
         s_idx = pm.take(slice_set_list[0].slice_index_of_particle, p_idx)
         bunch.yp[p_idx] += pm.take(constant_kick, s_idx)
 
@@ -197,7 +197,7 @@ class ConstantWakeKickZ(WakeKick):
         constant_kick = self._accumulate_source_signal(
             bunch, times_list, slice_set_age_list, moments_list, betas_list)
 
-        p_idx = slice_set_list[0].particles_within_cuts
+        p_idx = slice_set_list[0].particles_within_cuts_slice
         s_idx = pm.take(slice_set_list[0].slice_index_of_particle, p_idx)
         bunch.dp[p_idx] += pm.take(constant_kick, s_idx)
 

--- a/PyHEADTAIL/impedances/wake_kicks.py
+++ b/PyHEADTAIL/impedances/wake_kicks.py
@@ -158,7 +158,7 @@ class ConstantWakeKickX(WakeKick):
             bunch, times_list, slice_set_age_list, moments_list, betas_list)
 
         p_idx = slice_set_list[0].particles_within_cuts_slice
-        s_idx = pm.take(slice_set_list[0].slice_index_of_particle, p_idx)
+        s_idx = slice_set_list[0].slice_index_of_particle[p_idx]
         bunch.xp[p_idx] += pm.take(constant_kick, s_idx)
 
 
@@ -178,7 +178,7 @@ class ConstantWakeKickY(WakeKick):
             bunch, times_list, slice_set_age_list, moments_list, betas_list)
 
         p_idx = slice_set_list[0].particles_within_cuts_slice
-        s_idx = pm.take(slice_set_list[0].slice_index_of_particle, p_idx)
+        s_idx = slice_set_list[0].slice_index_of_particle[p_idx]
         bunch.yp[p_idx] += pm.take(constant_kick, s_idx)
 
 
@@ -198,7 +198,7 @@ class ConstantWakeKickZ(WakeKick):
             bunch, times_list, slice_set_age_list, moments_list, betas_list)
 
         p_idx = slice_set_list[0].particles_within_cuts_slice
-        s_idx = pm.take(slice_set_list[0].slice_index_of_particle, p_idx)
+        s_idx = slice_set_list[0].slice_index_of_particle[p_idx]
         bunch.dp[p_idx] += pm.take(constant_kick, s_idx)
 
 


### PR DESCRIPTION
This patch fixes the `IndexError` occurring when running longitudinal wakes 
(or constant transverse wakes) within a GPU context.

All wake kicks except for the constant ones acquired the particle indices `p_idx`
 within the slicing region via `particles_within_cuts_slice`, which is both CPU and 
GPU compatible. Only the constant wakes used the (old and) GPU-incompatible 
`particles_within_cuts` attribute of the SliceSet before this patch.

Thanks to Rob Williamson for reporting this issue.