### PR TITLE
Fixed inability to load wake fields with t>=0

### DIFF
--- a/PyHEADTAIL/impedances/wakes.py
+++ b/PyHEADTAIL/impedances/wakes.py
@@ -359,12 +359,13 @@ class WakeTable(WakeSource):
         interpolation_function = interp1d(time, wake_strength)
 
         def wake(dt, *args, **kwargs):
-            wake_interpolated = interpolation_function(-dt)
             if time[0] == 0:
+                wake_interpolated = interpolation_function(-dt.clip(max=0))
                 # Beam loading theorem: Half value of wake strength at
                 # dt = 0.
                 return (np.sign(-dt) + 1.) / 2. * wake_interpolated
             elif time[0] < 0:
+                wake_interpolated = interpolation_function(-dt)
                 return wake_interpolated
             else:
                 raise ValueError('Longitudinal wake component does not meet' +


### PR DESCRIPTION
The problem was in the function_longitudinal that caused ValueError when trying to load wake fields with time[0] = 0.