### PR TITLE
Adapt cython import to cython 3

### DIFF
--- a/PyHEADTAIL/cobra_functions/stats.pyx
+++ b/PyHEADTAIL/cobra_functions/stats.pyx
@@ -10,11 +10,7 @@ import numpy as np
 cimport numpy as np
 cimport libc.math as cmath
 
-cimport cython.boundscheck
-cimport cython.cdivision
-cimport cython.wraparound
-
-
+cimport cython
 
 @cython.boundscheck(False)
 @cython.cdivision(True)


### PR DESCRIPTION
Recent release of Cython 3 breaks the installation of PyHEADTAIL. The fix (suggested by the error message) is very simple:

```
Collecting PyHEADTAIL (from xpart==0.15.1)
[130](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:131)
  Downloading PyHEADTAIL-1.16.0.tar.gz (251 kB)
[131](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:132)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 251.0/251.0 kB 78.4 MB/s eta 0:00:00
[132](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:133)
  Preparing metadata (setup.py): started
[133](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:134)
  Preparing metadata (setup.py): finished with status 'error'
[134](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:135)
  error: subprocess-exited-with-error
[135](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:136)
  
[136](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:137)
  × python setup.py egg_info did not run successfully.
[137](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:138)
  │ exit code: 1
[138](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:139)
  ╰─> [54 lines of output]
[139](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:140)
      
[140](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:141)
      Error compiling Cython file:
[141](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:142)
      ------------------------------------------------------------
[142](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:143)
      ...
[143](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:144)
      
[144](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:145)
      import numpy as np
[145](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:146)
      cimport numpy as np
[146](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:147)
      cimport libc.math as cmath
[147](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:148)
      
[148](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:149)
      cimport cython.boundscheck
[149](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:150)
              ^
[150](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:151)
      ------------------------------------------------------------
[151](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:152)
      
[152](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:153)
      PyHEADTAIL/cobra_functions/stats.pyx:13:8: 'cython.boundscheck' is not a valid cython.* module. Instead, use 'import cython' and then 'cython.boundscheck'.
[153](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:154)
      
[154](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:155)
      Error compiling Cython file:
[155](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:156)
      ------------------------------------------------------------
[156](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:157)
      ...
[157](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:158)
      import numpy as np
[158](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:159)
      cimport numpy as np
[159](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:160)
      cimport libc.math as cmath
[160](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:161)
      
[161](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:162)
      cimport cython.boundscheck
[162](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:163)
      cimport cython.cdivision
[163](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:164)
              ^
[164](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:165)
      ------------------------------------------------------------
[165](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:166)
      
[166](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:167)
      PyHEADTAIL/cobra_functions/stats.pyx:14:8: 'cython.cdivision' is not a valid cython.* module. Instead, use 'import cython' and then 'cython.cdivision'.
[167](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:168)
      
[168](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:169)
      Error compiling Cython file:
[169](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:170)
      ------------------------------------------------------------
[170](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:171)
      ...
[171](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:172)
      cimport numpy as np
[172](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:173)
      cimport libc.math as cmath
[173](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:174)
      
[174](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:175)
      cimport cython.boundscheck
[175](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:176)
      cimport cython.cdivision
[176](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:177)
      cimport cython.wraparound
[177](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:178)
              ^
[178](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:179)
      ------------------------------------------------------------
[179](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:180)
      
[180](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:181)
      PyHEADTAIL/cobra_functions/stats.pyx:15:8: 'cython.wraparound' is not a valid cython.* module. Instead, use 'import cython' and then 'cython.wraparound'.
[181](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:182)
      Traceback (most recent call last):
[182](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:183)
        File "<string>", line 2, in <module>
[183](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:184)
        File "<pip-setuptools-caller>", line 34, in <module>
[184](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:185)
        File "/tmp/pip-install-b6ixtjr0/pyheadtail_2da9fe509f6a4982bdee2e34a1da5dd4/setup.py", line 77, in <module>
[185](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:186)
          ext_modules=cythonize(cy_ext, **cy_ext_options),
[186](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:187)
        File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1134, in cythonize
[187](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:188)
          cythonize_one(*args)
[188](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:189)
        File "/usr/share/miniconda3/envs/test/lib/python3.10/site-packages/Cython/Build/Dependencies.py", line 1301, in cythonize_one
[189](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:190)
          raise CompileError(None, pyx_file)
[190](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:191)
      Cython.Compiler.Errors.CompileError: PyHEADTAIL/cobra_functions/stats.pyx
[191](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:192)
      Compiling PyHEADTAIL/cobra_functions/stats.pyx because it changed.
[192](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:193)
      [1/1] Cythonizing PyHEADTAIL/cobra_functions/stats.pyx
[193](https://github.com/xsuite/xsuite/actions/runs/5580735649/jobs/10198038929#step:4:194)
      [end of output]
```