### PR TITLE
Release/v1.17.1 - a few small bugs with multi-bunch mode

### DIFF
--- a/PyHEADTAIL/aperture/aperture.py
+++ b/PyHEADTAIL/aperture/aperture.py
@@ -60,6 +60,7 @@ class Aperture(Element, metaclass=ABCMeta):
             beam.yp = beam.yp[:n_alive]
             beam.dp = beam.dp[:n_alive]
             beam.id = beam.id[:n_alive]
+            beam.bucket_id = beam.bucket_id[:n_alive]
 
     @abstractmethod
     def tag_lost_particles(self, beam):

--- a/PyHEADTAIL/aperture/aperture.py
+++ b/PyHEADTAIL/aperture/aperture.py
@@ -40,27 +40,31 @@ class Aperture(Element, metaclass=ABCMeta):
         currently cached slice_sets of the beam are cleaned since losses
         change its (longitudinal) state.
         '''
-        alive = self.tag_lost_particles(beam)
+        bunch_list = beam.split_to_views()
 
-        if not pm.all(alive):
-            # check whether all particles are lost, it's not safe to call
-            # the cython version of relocate_all_particles in this case
-            if not pm.any(alive):
-                self.warns('ALL particles were lost')
-                n_alive = 0
-            else:
-                # Move lost particles to the end of the beam.u arrays.
-                n_alive = self.relocate_lost_particles(beam, alive)
-            # Update beam.u arrays, i.e. remove lost particles.
-            beam.macroparticlenumber = n_alive
-            beam.x = beam.x[:n_alive]
-            beam.y = beam.y[:n_alive]
-            beam.z = beam.z[:n_alive]
-            beam.xp = beam.xp[:n_alive]
-            beam.yp = beam.yp[:n_alive]
-            beam.dp = beam.dp[:n_alive]
-            beam.id = beam.id[:n_alive]
-            beam.bucket_id = beam.bucket_id[:n_alive]
+        for b in bunch_list:
+
+            alive = self.tag_lost_particles(b)
+
+            if not pm.all(alive):
+                # check whether all particles are lost, it's not safe to call
+                # the cython version of relocate_all_particles in this case
+                if not pm.any(alive):
+                    self.warns('ALL particles were lost')
+                    n_alive = 0
+                else:
+                    # Move lost particles to the end of the beam.u arrays.
+                    n_alive = self.relocate_lost_particles(b, alive)
+                # Update beam.u arrays, i.e. remove lost particles.
+                b.macroparticlenumber = n_alive
+                b.x = b.x[:n_alive]
+                b.y = b.y[:n_alive]
+                b.z = b.z[:n_alive]
+                b.xp = b.xp[:n_alive]
+                b.yp = b.yp[:n_alive]
+                b.dp = b.dp[:n_alive]
+                b.id = b.id[:n_alive]
+                b.bucket_id = b.bucket_id[:n_alive]
 
     @abstractmethod
     def tag_lost_particles(self, beam):

--- a/PyHEADTAIL/cobra_functions/stats.pyx
+++ b/PyHEADTAIL/cobra_functions/stats.pyx
@@ -10,11 +10,7 @@ import numpy as np
 cimport numpy as np
 cimport libc.math as cmath
 
-cimport cython.boundscheck
-cimport cython.cdivision
-cimport cython.wraparound
-
-
+import cython
 
 @cython.boundscheck(False)
 @cython.cdivision(True)

--- a/PyHEADTAIL/feedback/feedback.py
+++ b/PyHEADTAIL/feedback/feedback.py
@@ -46,7 +46,7 @@ class IdealBunchFeedback(object):
 class IdealSliceFeedback(object):
     """Corrects a gain fraction of a mean xp/yp value of each slice in the bunch."""
     def __init__(self,gain,slicer, multi_bunch=False):
-        if if hasattr(gain, '__getitem__'):
+        if hasattr(gain, '__getitem__'):
             self._gain_x = gain[0]
             self._gain_y = gain[1]
         else:
@@ -88,7 +88,7 @@ class GenericOneTurnMapObject(object):
                  phase_x=None, phase_y=None, location_x=0., location_y=0.,
                  beta_x=1., beta_y=1., **kwargs):
         
-        if if hasattr(gain, '__getitem__'):
+        if hasattr(gain, '__getitem__'):
             self._gain_x = gain[0]
             self._gain_y = gain[1]
         else:

--- a/PyHEADTAIL/feedback/feedback.py
+++ b/PyHEADTAIL/feedback/feedback.py
@@ -1,4 +1,3 @@
-import collections
 import numpy as np
 from scipy.constants import c
 
@@ -22,7 +21,7 @@ class IdealBunchFeedback(object):
     """ The simplest possible feedback. It corrects a gain fraction of a mean xp/yp value of the bunch.
     """
     def __init__(self,gain, multi_bunch=False):
-        if isinstance(gain, collections.Container):
+        if if hasattr(gain, '__getitem__'):
             self._gain_x = gain[0]
             self._gain_y = gain[1]
         else:
@@ -47,7 +46,7 @@ class IdealBunchFeedback(object):
 class IdealSliceFeedback(object):
     """Corrects a gain fraction of a mean xp/yp value of each slice in the bunch."""
     def __init__(self,gain,slicer, multi_bunch=False):
-        if isinstance(gain, collections.Container):
+        if if hasattr(gain, '__getitem__'):
             self._gain_x = gain[0]
             self._gain_y = gain[1]
         else:
@@ -89,7 +88,7 @@ class GenericOneTurnMapObject(object):
                  phase_x=None, phase_y=None, location_x=0., location_y=0.,
                  beta_x=1., beta_y=1., **kwargs):
         
-        if isinstance(gain, collections.Container):
+        if if hasattr(gain, '__getitem__'):
             self._gain_x = gain[0]
             self._gain_y = gain[1]
         else:

--- a/PyHEADTAIL/feedback/feedback.py
+++ b/PyHEADTAIL/feedback/feedback.py
@@ -21,7 +21,7 @@ class IdealBunchFeedback(object):
     """ The simplest possible feedback. It corrects a gain fraction of a mean xp/yp value of the bunch.
     """
     def __init__(self,gain, multi_bunch=False):
-        if if hasattr(gain, '__getitem__'):
+        if hasattr(gain, '__getitem__'):
             self._gain_x = gain[0]
             self._gain_y = gain[1]
         else:

--- a/PyHEADTAIL/particles/particles.py
+++ b/PyHEADTAIL/particles/particles.py
@@ -321,6 +321,22 @@ class ParticlesView(Printing):
 
         return slice_object_list
 
+    def reorder(self, permutation, except_for_attrs=[]):
+        '''Reorder all particle coordinate and momentum arrays
+        (in self.coords_n_momenta) and ids except for except_for_attrs
+        according to the given index array permutation.
+        '''
+        to_be_reordered = ['id'] + list(self.coords_n_momenta) 
+        for attr in to_be_reordered:
+            if attr in except_for_attrs:
+                continue
+            reordered = pm.apply_permutation(getattr(self, '_'+ attr), permutation)
+            setattr(self, '_'+ attr, reordered)
+
+        reordered = pm.apply_permutation(getattr(self, 'bucket_id'), permutation)
+        setattr(self, 'bucket_id', reordered)
+        self.clean_slices()
+
     def clean_slices(self):
         '''Erases the SliceSet records of this Particles instance.
         Any longitudinal trackers (or otherwise modifying elements)

--- a/PyHEADTAIL/trackers/transverse_tracking.py
+++ b/PyHEADTAIL/trackers/transverse_tracking.py
@@ -147,53 +147,59 @@ class TransverseSegmentMap(Element):
         # Calculate phase advance for this segment (betatron motion in
         # this segment and incoherent tune shifts introduced by detuning
         # effects).
-        dphi_x = self.dQ_x
-        dphi_y = self.dQ_y
 
-        dphi_is_array = False
 
-        for element in self.segment_detuners:
-            detune_x, detune_y = element.detune(beam)
-            dphi_x += detune_x
-            dphi_y += detune_y
-            dphi_is_array = True
+        bunch_list = beam.split_to_views()
 
-        dphi_x *= 2.*np.pi
-        dphi_y *= 2.*np.pi
+        for i, b in enumerate(bunch_list):
 
-        # needs to be pm.cos, cos alone not possible:
-        # the change in the pm namespace has to be visible here
-        # --> use of named vars better style anyway
-        # another problem is that dphi_x can be either a scalar (no detuning)
-        # or an array (with detuning): somehow discriminate between the two
-        # bc. cumath.cos() can't handle scalars. For now simply put an if/else,
-        # think about better solutions
-        if dphi_is_array:
-            s_dphi_x, c_dphi_x = pm.sincos(pm.atleast_1d(dphi_x))
-            s_dphi_y, c_dphi_y = pm.sincos(pm.atleast_1d(dphi_y))
-            # c_dphi_x = pm.cos(dphi_x)
-            # c_dphi_y = pm.cos(dphi_y)
-            # s_dphi_x = pm.sin(dphi_x)
-            # s_dphi_y = pm.sin(dphi_y)
-        else:
-            c_dphi_x = np.cos(dphi_x)
-            c_dphi_y = np.cos(dphi_y)
-            s_dphi_x = np.sin(dphi_x)
-            s_dphi_y = np.sin(dphi_y)
+            dphi_x = self.dQ_x
+            dphi_y = self.dQ_y
 
-        # Calculate the matrix M and transport the transverse phase
-        # spaces through the segment.
-        M00 = self.I[0, 0] * c_dphi_x + self.J[0, 0] * s_dphi_x
-        M01 = self.I[0, 1] * c_dphi_x + self.J[0, 1] * s_dphi_x
-        M10 = self.I[1, 0] * c_dphi_x + self.J[1, 0] * s_dphi_x
-        M11 = self.I[1, 1] * c_dphi_x + self.J[1, 1] * s_dphi_x
-        M22 = self.I[2, 2] * c_dphi_y + self.J[2, 2] * s_dphi_y
-        M23 = self.I[2, 3] * c_dphi_y + self.J[2, 3] * s_dphi_y
-        M32 = self.I[3, 2] * c_dphi_y + self.J[3, 2] * s_dphi_y
-        M33 = self.I[3, 3] * c_dphi_y + self.J[3, 3] * s_dphi_y
+            dphi_is_array = False
 
-        # bound to _track_with_dispersion or _track_without_dispersion
-        self._track(beam, M00, M01, M10, M11, M22, M23, M32, M33)
+            for element in self.segment_detuners:
+                detune_x, detune_y = element.detune(b)
+                dphi_x += detune_x
+                dphi_y += detune_y
+                dphi_is_array = True
+
+            dphi_x *= 2.*np.pi
+            dphi_y *= 2.*np.pi
+
+            # needs to be pm.cos, cos alone not possible:
+            # the change in the pm namespace has to be visible here
+            # --> use of named vars better style anyway
+            # another problem is that dphi_x can be either a scalar (no detuning)
+            # or an array (with detuning): somehow discriminate between the two
+            # bc. cumath.cos() can't handle scalars. For now simply put an if/else,
+            # think about better solutions
+            if dphi_is_array:
+                s_dphi_x, c_dphi_x = pm.sincos(pm.atleast_1d(dphi_x))
+                s_dphi_y, c_dphi_y = pm.sincos(pm.atleast_1d(dphi_y))
+                # c_dphi_x = pm.cos(dphi_x)
+                # c_dphi_y = pm.cos(dphi_y)
+                # s_dphi_x = pm.sin(dphi_x)
+                # s_dphi_y = pm.sin(dphi_y)
+            else:
+                c_dphi_x = np.cos(dphi_x)
+                c_dphi_y = np.cos(dphi_y)
+                s_dphi_x = np.sin(dphi_x)
+                s_dphi_y = np.sin(dphi_y)
+
+            # Calculate the matrix M and transport the transverse phase
+            # spaces through the segment.
+            M00 = self.I[0, 0] * c_dphi_x + self.J[0, 0] * s_dphi_x
+            M01 = self.I[0, 1] * c_dphi_x + self.J[0, 1] * s_dphi_x
+            M10 = self.I[1, 0] * c_dphi_x + self.J[1, 0] * s_dphi_x
+            M11 = self.I[1, 1] * c_dphi_x + self.J[1, 1] * s_dphi_x
+            M22 = self.I[2, 2] * c_dphi_y + self.J[2, 2] * s_dphi_y
+            M23 = self.I[2, 3] * c_dphi_y + self.J[2, 3] * s_dphi_y
+            M32 = self.I[3, 2] * c_dphi_y + self.J[3, 2] * s_dphi_y
+            M33 = self.I[3, 3] * c_dphi_y + self.J[3, 3] * s_dphi_y
+
+            # bound to _track_with_dispersion or _track_without_dispersion
+            self._track(b, M00, M01, M10, M11, M22, M23, M32, M33)
 
 
 class TransverseMap(Printing):


### PR DESCRIPTION
We fix a few small small bugs:

1. Some cython `cimports` won't work with the latest version and they can be simplified
2. We fix a bug with `collection.Containers`
3. We add the `reorder` function in ParticleView, copying from to the one in `Particles` (needed for the aperture module)
4. We handle the reordering of the `bucket_id` in the aperture module
5. In `TransverseSegmentMap.track` we do the tracking looping over the bunches. This is important when running in multi-bunch mode. The same loop over the bunches is also added in `Aperture.track`