### PR TITLE
Release/v1.17.1

### DIFF
--- a/PyHEADTAIL/particles/particles.py
+++ b/PyHEADTAIL/particles/particles.py
@@ -217,7 +217,7 @@ class ParticlesView(Printing):
         '''Return a dictionary containing the coordinate and conjugate
         momentum arrays.
         '''
-        return {coord: getattr(self, np.copy('_'+coord)) for coord in self.coords_n_momenta}
+        return {coord: getattr(self, '_'+str(coord)) for coord in self.coords_n_momenta}
 
     def get_slices(self, slicer, *args, **kwargs):
         '''For the given Slicer, the last SliceSet is returned.

--- a/PyHEADTAIL/particles/particles.py
+++ b/PyHEADTAIL/particles/particles.py
@@ -217,7 +217,7 @@ class ParticlesView(Printing):
         '''Return a dictionary containing the coordinate and conjugate
         momentum arrays.
         '''
-        return {coord: getattr(self, '_'+str(coord)) for coord in self.coords_n_momenta}
+        return {coord: np.copy(getattr(self, '_'+str(coord))) for coord in self.coords_n_momenta}
 
     def get_slices(self, slicer, *args, **kwargs):
         '''For the given Slicer, the last SliceSet is returned.


### PR DESCRIPTION
When running the code with Python 3.11.6, the following error is encountered in `particles/particles.py` (in `get_coords_n_momenta_dict`, in `ParticlesView` class):

`TypeError: attribute name must be string, not 'numpy.ndarray'`

To avoid the error, the following modification is done:
`return {coord: np.copy(getattr(self, '_'+str(coord))) for coord in self.coords_n_momenta}`