### PR TITLE
Fixes for Scipy 1.14.0

### DIFF
--- a/PyHEADTAIL/cobra_functions/pdf_integrators_2d.py
+++ b/PyHEADTAIL/cobra_functions/pdf_integrators_2d.py
@@ -5,7 +5,13 @@
 '''
 
 import numpy as np
-from scipy.integrate import quad, dblquad, cumtrapz, romb
+from scipy.integrate import quad, dblquad, romb
+
+try:
+    from scipy.integrate import cumulative_trapezoid
+    cumtrapz = cumulative_trapezoid
+except ImportError:
+    from scipy.integrate import cumtrapz  # removed in scipy>=1.14.0
 
 
 def quad2d(f, ylimits, xmin, xmax):


### PR DESCRIPTION
Following the new release of numpy 2.0 there is a new release of scipy 1.14 that removes some previously deprecated functionality: https://github.com/scipy/scipy/releases/tag/v1.14.0. This PR updates xpart to be compatible with these changes.