### PR TITLE
Fixes in longitudinal wake

### DIFF
--- a/PyHEADTAIL/impedances/wakes.py
+++ b/PyHEADTAIL/impedances/wakes.py
@@ -355,8 +355,12 @@ class WakeTable(WakeSource):
         convert_to_V_per_C = 1e12
 
         time = convert_to_s * self.wake_table['time']
-        wake_strength = -convert_to_V_per_C * self.wake_table['longitudinal']
-        interpolation_function = interp1d(time, wake_strength)
+        # Sign is chosen such that a positive wake corresponds to energy
+        # loss (giadarol, 6 July 2024)
+        wake_strength = convert_to_V_per_C * self.wake_table['longitudinal']
+        interpolation_function = interp1d(time, wake_strength,
+                                          bounds_error=False,
+                                          fill_value=0.)
 
         def wake(dt, *args, **kwargs):
             wake_interpolated = interpolation_function(-dt)


### PR DESCRIPTION
Changes:
* Corrected the sign of `wake_strength` in `function_longitudinal` to ensure a positive wake corresponds to energy loss.
* Correct the `interp1d` interpolation function by adding `bounds_error=False` and `fill_value=0` as done elsewhere 