### PR TITLE
Minimum requirements for PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "Cython", "numpy", "scipy", "h5py"]

--- a/setup.py
+++ b/setup.py
@@ -76,12 +76,11 @@ setup(
     cmdclass={'build_ext': build_ext},
     ext_modules=cythonize(cy_ext, **cy_ext_options),
     include_package_data=True,  # install files matched by MANIFEST.in
-    setup_requires=[
+    install_requires=[
         'h5py',
         'numpy',
         'scipy',
-        'cython',
-    ]
+    ],
 )
 
 # from numpy.distutils.core import setup, Extension


### PR DESCRIPTION
At the moment it is not possible to install PyHEADTAIL in a clean Python environment, as the `setup.py` script itself requires numpy and Cython. This introduces the build requirements in the `pyproject.toml` file as required by PEP 518.